### PR TITLE
Add new CSS changes for Traffic Count Attachments project

### DIFF
--- a/code/data-tracker.css
+++ b/code/data-tracker.css
@@ -54,3 +54,13 @@
 /* hide attachment type column (field contents are extracted via JS */
 div.view_2107 .field_2403 { display: none; }
 div.view_2108 .field_2403 { display: none; }
+
+/* hide attachment type columns (in Traffic Counts), field contents extracted via JS */
+div.view_2357 .field_3174 { display: none; }
+div.view_2486 .field_3174 { display: none; }
+
+/* hide attachment type columns (in Manage Requests under Traffic Counts), field contents extracted via JS */
+div.view_2491 .field_3174 { display: none; }
+
+/* hide attachment type columns (in Request Status under Traffic Counts), field contents extracted via JS */
+div.view_2465 .field_3174 { display: none; }


### PR DESCRIPTION
The changes I'm proposing here are just the changes I made to the CSS file for the Data Tracker that allow us to use JavaScript to retrieve the attachment type category names and then hide the attachment type column in our tables on those pages.